### PR TITLE
Capture context instead of using unsafe.Pointer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/myles-keough/gowinlog
+module github.com/huntresslabs/gowinlog
 
 go 1.14
 


### PR DESCRIPTION
This captures the context inside a lambda instead of expecting it to remain in the same place in memory.