### PR TITLE
Disable localized fields by default and return xml as []byte

### DIFF
--- a/event_test.go
+++ b/event_test.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package winlog
@@ -171,4 +172,35 @@ func BenchmarkAPIDecode(b *B) {
 			b.Fatal(err)
 		}
 	}
+}
+
+func TestRemoveZeroBytes(t *T) {
+	testEq := func(a, b []byte) {
+		if len(a) != len(b) {
+			t.Fatalf("%v does not equal %v", a, b)
+			return
+		}
+		for index := range a {
+			if a[index] != b[index] {
+				t.Fatalf("%v does not equal %v", a, b)
+				return
+			}
+		}
+	}
+
+	testCase1 := []byte{0, 0, 1, 2, 3}
+	removeZeroBytes(&testCase1)
+	testEq(testCase1, []byte{1, 2, 3})
+
+	testCase2 := []byte{0, 0}
+	removeZeroBytes(&testCase2)
+	testEq(testCase2, []byte{})
+
+	testCase3 := []byte{}
+	removeZeroBytes(&testCase3)
+	testEq(testCase3, []byte{})
+
+	testCase4 := []byte{1, 2, 3, 0}
+	removeZeroBytes(&testCase4)
+	testEq(testCase4, []byte{1, 2, 3})
 }

--- a/event_test.go
+++ b/event_test.go
@@ -203,4 +203,10 @@ func TestRemoveZeroBytes(t *T) {
 	testCase4 := []byte{1, 2, 3, 0}
 	removeZeroBytes(&testCase4)
 	testEq(testCase4, []byte{1, 2, 3})
+
+	var testCase5 []byte
+	removeZeroBytes(&testCase5)
+	testEq(testCase5, nil)
+
+	removeZeroBytes(nil)
 }

--- a/structs.go
+++ b/structs.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package winlog
@@ -10,7 +11,7 @@ import (
 // Stores the common fields from a log event
 type WinLogEvent struct {
 	// XML
-	Xml    string
+	Xml    []byte
 	XmlErr error
 
 	// From EvtRender

--- a/winlogwatcher.go
+++ b/winlogwatcher.go
@@ -1,6 +1,7 @@
+//go:build windows
 // +build windows
 
-//Winlog hooks into the Windows Event Log and streams events through channels
+// Winlog hooks into the Windows Event Log and streams events through channels
 package winlog
 
 import (
@@ -27,19 +28,11 @@ func NewWinLogWatcher() (*WinLogWatcher, error) {
 		return nil, err
 	}
 	return &WinLogWatcher{
-		shutdown:       make(chan interface{}),
-		errChan:        make(chan error),
-		eventChan:      make(chan *WinLogEvent),
-		renderContext:  cHandle,
-		watches:        make(map[string]*channelWatcher),
-		RenderKeywords: true,
-		RenderMessage:  true,
-		RenderLevel:    true,
-		RenderTask:     true,
-		RenderProvider: true,
-		RenderOpcode:   true,
-		RenderChannel:  true,
-		RenderId:       true,
+		shutdown:      make(chan interface{}),
+		errChan:       make(chan error),
+		eventChan:     make(chan *WinLogEvent),
+		renderContext: cHandle,
+		watches:       make(map[string]*channelWatcher),
 	}, nil
 }
 
@@ -215,10 +208,10 @@ func (self *WinLogWatcher) convertEvent(handle EventHandle, subscribedChannel st
 			if self.RenderId {
 				idText, _ = FormatMessage(publisherHandle, handle, EvtFormatMessageId)
 			}
+
+			CloseEventHandle(uint64(publisherHandle))
 		}
 	}
-
-	CloseEventHandle(uint64(publisherHandle))
 
 	event := WinLogEvent{
 		Xml:               xml,


### PR DESCRIPTION
This disables the localized fields by default and removes some full copies of the event XML. A previous developer left us a note about about localized fields being slow, and that indeed appears to have been using most of the CPU time.