### PR TITLE
Fix UTF-16 to UTF-8 conversion

### DIFF
--- a/event.go
+++ b/event.go
@@ -124,17 +124,15 @@ func RenderEventXML(eventHandle EventHandle) ([]byte, error) {
 		return nil, err
 	}
 
-	buffer := make([]byte, bufferUsed)
+	buffer := make([]uint16, bufferUsed)
 	bufSize := bufferUsed
 
-	err = EvtRender(0, syscall.Handle(eventHandle), EvtRenderEventXml, bufSize, (*uint16)(unsafe.Pointer(&buffer[0])), &bufferUsed, &propertyCount)
+	err = EvtRender(0, syscall.Handle(eventHandle), EvtRenderEventXml, bufSize, &buffer[0], &bufferUsed, &propertyCount)
 	if err != nil {
 		return nil, err
 	}
 
-	removeZeroBytes(&buffer)
-
-	return buffer, nil
+	return []byte(syscall.UTF16ToString(buffer)), nil
 }
 
 /* Get a handle that represents the publisher of the event, given the rendered event values. */
@@ -229,20 +227,4 @@ func (ev *WinLogEvent) CreateMap() map[string]interface{} {
 	toReturn["SubscribedChannel"] = ev.SubscribedChannel
 	toReturn["Bookmark"] = ev.Bookmark
 	return toReturn
-}
-
-// Removes null bytes in place
-func removeZeroBytes(buffer *[]byte) {
-	if buffer == nil {
-		return
-	}
-	var read, write int
-	for ; read < len(*buffer); read++ {
-		if (*buffer)[read] == 0 {
-			continue
-		}
-		(*buffer)[write] = (*buffer)[read]
-		write++
-	}
-	*buffer = (*buffer)[:write]
 }

--- a/event_test.go
+++ b/event_test.go
@@ -62,6 +62,7 @@ type WinLogEventXml struct {
 }
 
 func assertEqual(a, b interface{}, t *T) {
+	t.Helper()
 	if a != b {
 		t.Fatalf("%v != %v", a, b)
 	}
@@ -172,41 +173,4 @@ func BenchmarkAPIDecode(b *B) {
 			b.Fatal(err)
 		}
 	}
-}
-
-func TestRemoveZeroBytes(t *T) {
-	testEq := func(a, b []byte) {
-		if len(a) != len(b) {
-			t.Fatalf("%v does not equal %v", a, b)
-			return
-		}
-		for index := range a {
-			if a[index] != b[index] {
-				t.Fatalf("%v does not equal %v", a, b)
-				return
-			}
-		}
-	}
-
-	testCase1 := []byte{0, 0, 1, 2, 3}
-	removeZeroBytes(&testCase1)
-	testEq(testCase1, []byte{1, 2, 3})
-
-	testCase2 := []byte{0, 0}
-	removeZeroBytes(&testCase2)
-	testEq(testCase2, []byte{})
-
-	testCase3 := []byte{}
-	removeZeroBytes(&testCase3)
-	testEq(testCase3, []byte{})
-
-	testCase4 := []byte{1, 2, 3, 0}
-	removeZeroBytes(&testCase4)
-	testEq(testCase4, []byte{1, 2, 3})
-
-	var testCase5 []byte
-	removeZeroBytes(&testCase5)
-	testEq(testCase5, nil)
-
-	removeZeroBytes(nil)
 }


### PR DESCRIPTION
The existing code to handle the UTF-16 to UTF-8 conversion was only correct if the text consisted entirely of ASCII characters.
