### PR TITLE
Properly capture errors from Windows Event Log callback

### DIFF
--- a/winevt.go
+++ b/winevt.go
@@ -62,6 +62,13 @@ const (
 	EvtSubscribeStartAfterBookmark
 )
 
+type EVT_SUBSCRIBE_NOTIFY_ACTION int
+
+const (
+	EvtSubscribeActionError = iota
+	EvtSubscribeActionDeliver
+)
+
 /* Fields that can be rendered with GetRendered*Value */
 type EVT_SYSTEM_PROPERTY_ID int
 


### PR DESCRIPTION
When there is an error sent into the Windows Event Log callback, we're not retrieving the error properly, causing us to log:
```
Windows event log watcher error: Event log callback got error: <nil>
```